### PR TITLE
Added 'wc' shorthand for --without-referenced-comments

### DIFF
--- a/pigar/__main__.py
+++ b/pigar/__main__.py
@@ -141,6 +141,7 @@ parser.add_argument(
     help='The comparison operator for versions, alternatives: [==, ~=, >=].'
 )
 parser.add_argument(
+    '-wc',
     '--without-referenced-comments',
     dest='ref_comments',
     action='store_false',


### PR DESCRIPTION
Added a shorthand of 'wc' for the omit comments option, previously --without-referenced-comments. The previous one was way too long to practically type out every time. If you have a better idea for the name instead of 'wc', I don't mind, as long as it's something that's terse to type and remember.